### PR TITLE
We are counting (near) matches, not edits, so we want 1-weight.

### DIFF
--- a/segeval/similarity/__init__.py
+++ b/segeval/similarity/__init__.py
@@ -103,7 +103,7 @@ def __boundary_confusion_matrix__(*args, **kwargs):
     # Add weighted near misses
     for transposition in statistics['transpositions']:
         match = transposition[2]
-        matrix[match][match] += fnc_weight_t([transposition], n_t)
+        matrix[match][match] += (1 - fnc_weight_t([transposition], n_t))
     # Add confusion errors
     for substitution in statistics['substitutions']:
         hyp, ref = substitution

--- a/segeval/similarity/test.py
+++ b/segeval/similarity/test.py
@@ -37,6 +37,16 @@ class TestSimilarity(unittest.TestCase):
         self.assertEqual(cm[1][1], Decimal('1.5'))
         self.assertEqual(cm[2][2], 0)
 
+    def test_boundary_confusion_matrix_wide_transposition(self):
+        cm1 = boundary_confusion_matrix([5,5], [4,6], n_t=4)
+        self.assertEqual(cm1[None][1], 0)
+        self.assertEqual(cm1[1][None], 0)
+        self.assertEqual(cm1[1][1], Decimal('0.75'))
+        cm2 = boundary_confusion_matrix([5,5], [2,8], n_t=4)
+        self.assertEqual(cm2[None][1], 0)
+        self.assertEqual(cm2[1][None], 0)
+        self.assertEqual(cm2[1][1], Decimal('0.25'))
+
     def test_boundary_statistics(self):
         '''
         Test boundary statistics.


### PR DESCRIPTION
I believe that transportations were being weighted incorrectly for `n_t > 2`. In the confusion matrix we want close transpositions to be closer to 1.
